### PR TITLE
Reorder link libraries

### DIFF
--- a/perl/Makefile.PL
+++ b/perl/Makefile.PL
@@ -2,7 +2,7 @@ use ExtUtils::MakeMaker;
 WriteMakefile(
 			  NAME         => 'Tabix',
 			  VERSION_FROM => 'Tabix.pm',
-			  LIBS         => ['-lz -L.. -ltabix'],
+			  LIBS         => ['-L.. -ltabix -lz'],
 			  DEFINE       => '-D_FILE_OFFSET_BITS=64 -D_USE_KNETFILE',
 			  INC          => '-I..',
 			 );


### PR DESCRIPTION
Move -lz after libtabix.a, as it is needed to resolve names used in libtabix.a.  Modern linkers have started requiring user care in library ordering again -- in particular, without this the resulting Tabix.so is faulty on Ubuntu 12.04.1 LTS (Precise Pangolin).
